### PR TITLE
Extranjerismo corregido

### DIFF
--- a/UD01/UD01_ES.md
+++ b/UD01/UD01_ES.md
@@ -685,10 +685,10 @@ Los **Operadores Lógicos** permiten realizar operaciones lógicas:
 
 | Operador   | Uso                 | Operación                                                    |
 | ---------- | ------------------- | ------------------------------------------------------------ |
-| `&&` o `&` | `a&&b` o<br />`a&b` | a AND b. El resultado será true si ambos operadores son true y false en caso contrario. |
-| `||` o `|` | `a||b` o<br />`a|b` | a OR b. El resultado será false si ambos operandos son false y true en caso contrario |
-| `!`        | `!a`                | NOT a. Si el operando es true el resultado es false y si el operando es false el resultado es true. |
-| `^`        | `a^b`               | a XOR b. El resultado será true si un operando es true y el otro false, y false en caso contrario. |
+| `&&` o `&` | `a&&b` o<br />`a&b` | a AND b. El resultado será *true* si ambos operadores son *true* y *false* en caso contrario. |
+| `||` o `|` | `a||b` o<br />`a|b` | a OR b. El resultado será *false* si ambos operandos son *false* y *true* en caso contrario |
+| `!`        | `!a`                | NOT a. Si el operando es *true* el resultado es *false* y si el operando es *false* el resultado es *true*. |
+| `^`        | `a^b`               | a XOR b. El resultado será *true* si un operando es *true* y el otro *false*, y *false* en caso contrario. |
 
 Ejemplo:
 


### PR DESCRIPTION
Modificación realizada por Guillem Ruiz.
Es recomendable que los extranjerismos se escriban entrecomillados o en cursiva